### PR TITLE
Feat render recipes

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,7 +5,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 import HomeScreen from "./src/screens/HomeScreen";
 import Camera from "./src/screens/Camera";
-import Preview from "./src/screens/preview";
+import Preview from "./src/screens/Preview";
 import Recipes from "./src/screens/Recipes";
 import RecipeDetails from "./src/screens/RecipeDetails";
 import * as firebase from "firebase";

--- a/App.js
+++ b/App.js
@@ -7,6 +7,7 @@ import HomeScreen from "./src/screens/HomeScreen";
 import Camera from "./src/screens/Camera";
 import Preview from "./src/screens/preview";
 import Recipes from "./src/screens/Recipes";
+import RecipeDetails from "./src/screens/RecipeDetails";
 import * as firebase from "firebase";
 import { YellowBox } from "react-native";
 
@@ -35,6 +36,7 @@ function App() {
           <Stack.Screen name="Camera" component={Camera} />
           <Stack.Screen name="Preview" component={Preview} />
           <Stack.Screen name="Recipes" component={Recipes} />
+          <Stack.Screen name="RecipeDetails" component={RecipeDetails} />
         </Stack.Navigator>
       </NavigationContainer>
     </Provider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,6 +6566,11 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.9.0.tgz",
       "integrity": "sha512-5MaiUD6HA3nzY3JbVI8l3V7pKedtxQF3d8qktTVI0WmWXTI4QzqOU8r8fPVvfKo3MhOXwhWBjr+kQ7DZaIQQeg=="
     },
+    "react-native-table-component": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-table-component/-/react-native-table-component-1.2.1.tgz",
+      "integrity": "sha512-sapwO0bONfQtpWg3GVMwP5D3lGEJlxPB3c7fb0soXBynvCa+SBktacVZ9OmYJnIbRJ3uW5pS4tzNc8GmE+UScw=="
+    },
     "react-native-unordered-list": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-native-unordered-list/-/react-native-unordered-list-1.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4835,6 +4835,14 @@
         "leven": "^3.1.0"
       }
     },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -4936,6 +4944,11 @@
       "requires": {
         "buffer-alloc": "^1.1.0"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "merge-stream": {
       "version": "1.0.1",
@@ -6521,6 +6534,15 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-native-hyperlink": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/react-native-hyperlink/-/react-native-hyperlink-0.0.19.tgz",
+      "integrity": "sha512-x4wuRGDMnnpWcRr5MCK1D2UcEuzD9IHK8lfjEhO/+QqXNaX31HdeD3ss3BXXZgHxpRYtLbTB0TuFcl1HHANp3w==",
+      "requires": {
+        "linkify-it": "^2.2.0",
+        "mdurl": "^1.0.0"
+      }
+    },
     "react-native-iphone-x-helper": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz",
@@ -6543,6 +6565,11 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.9.0.tgz",
       "integrity": "sha512-5MaiUD6HA3nzY3JbVI8l3V7pKedtxQF3d8qktTVI0WmWXTI4QzqOU8r8fPVvfKo3MhOXwhWBjr+kQ7DZaIQQeg=="
+    },
+    "react-native-unordered-list": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-unordered-list/-/react-native-unordered-list-1.0.4.tgz",
+      "integrity": "sha512-fLQxuE0xVeqxNiJMWIU1owpshZUJHmvgUF0z50qVjKZ8O8e9jiHPdr7us3SVghWYNws0qd/InGJCsz3VrNBu5w=="
     },
     "react-native-web": {
       "version": "0.11.7",
@@ -7471,6 +7498,11 @@
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-es": {
       "version": "3.3.9",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^8.2.0",
     "expo": "~38.0.8",
     "expo-camera": "~8.3.1",
+    "expo-constants": "~9.1.1",
     "expo-font": "~8.2.1",
     "expo-image-picker": "~8.3.0",
     "expo-status-bar": "^1.0.2",
@@ -29,14 +30,15 @@
     "react-dom": "~16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz",
     "react-native-gesture-handler": "~1.6.0",
+    "react-native-hyperlink": "0.0.19",
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",
+    "react-native-unordered-list": "^1.0.4",
     "react-native-web": "~0.11.7",
     "react-redux": "^7.2.1",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0",
-    "expo-constants": "~9.1.1"
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",
+    "react-native-table-component": "^1.2.1",
     "react-native-unordered-list": "^1.0.4",
     "react-native-web": "~0.11.7",
     "react-redux": "^7.2.1",

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Text, View, ActivityIndicator } from "react-native";
+
+export default function Loading() {
+  const color = "#b3d89cff";
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: "center",
+        backgroundColor: "#5d3a00ff",
+      }}
+    >
+      <Text style={{ color: color }}>Niles: </Text>
+      <Text style={{ color: color }}>"Going as fast as I can.."</Text>
+      <ActivityIndicator size="large" color={color} />
+    </View>
+  );
+}

--- a/src/components/Recipe/index.js
+++ b/src/components/Recipe/index.js
@@ -14,7 +14,7 @@ import {
   AlfaSlabOne_400Regular,
 } from "@expo-google-fonts/alfa-slab-one";
 
-export default function Recipe(prop) {
+export default function Recipe(props) {
   const [fontsLoaded] = useFonts({
     AlfaSlabOne_400Regular,
   });
@@ -35,21 +35,24 @@ export default function Recipe(prop) {
     totalNutrients,
     totalDaily,
     totalWeight,
-  } = prop;
+  } = props;
 
   if (!fontsLoaded) {
     return <AppLoading />;
   } else {
     return (
-      <TouchableOpacity style={styles.touch}>
-        <View style={styles.recipeCard}>
-          <Image
-            style={styles.image}
-            source={{ uri: image ? image : placeholder }}
-          />
-          <Text style={styles.title}>{title}</Text>
-        </View>
-      </TouchableOpacity>
+      // <TouchableOpacity
+      //   style={styles.touch}
+      //   onPress={() => navigation.navigate("RecipeDetails", props)}
+      // >
+      <View style={styles.recipeCard}>
+        <Image
+          style={styles.image}
+          source={{ uri: image ? image : placeholder }}
+        />
+        <Text style={styles.title}>{title}</Text>
+      </View>
+      // </TouchableOpacity>
     );
   }
 }

--- a/src/components/Recipe/index.js
+++ b/src/components/Recipe/index.js
@@ -1,11 +1,10 @@
 import React from "react";
-import { Text, View, StyleSheet, Image } from "react-native";
+import { Text, View, StyleSheet, Image, ActivityIndicator } from "react-native";
 import placeholder from "../../images/placeholder.png";
 import {
   useFonts,
   AlfaSlabOne_400Regular,
 } from "@expo-google-fonts/alfa-slab-one";
-import Loading from "../Loading";
 
 export default function Recipe(props) {
   const [fontsLoaded] = useFonts({
@@ -31,7 +30,7 @@ export default function Recipe(props) {
   } = props;
 
   if (!fontsLoaded) {
-    return <Loading />;
+    return <ActivityIndicator color="#a53f2bff" />;
   } else {
     return (
       <View style={styles.recipeCard}>

--- a/src/components/Recipe/index.js
+++ b/src/components/Recipe/index.js
@@ -1,18 +1,11 @@
 import React from "react";
-import {
-  Text,
-  View,
-  Button,
-  StyleSheet,
-  Image,
-  TouchableOpacity,
-} from "react-native";
+import { Text, View, StyleSheet, Image } from "react-native";
 import placeholder from "../../images/placeholder.png";
-import { AppLoading } from "expo";
 import {
   useFonts,
   AlfaSlabOne_400Regular,
 } from "@expo-google-fonts/alfa-slab-one";
+import Loading from "../Loading";
 
 export default function Recipe(props) {
   const [fontsLoaded] = useFonts({
@@ -38,13 +31,9 @@ export default function Recipe(props) {
   } = props;
 
   if (!fontsLoaded) {
-    return <AppLoading />;
+    return <Loading />;
   } else {
     return (
-      // <TouchableOpacity
-      //   style={styles.touch}
-      //   onPress={() => navigation.navigate("RecipeDetails", props)}
-      // >
       <View style={styles.recipeCard}>
         <Image
           style={styles.image}
@@ -52,7 +41,6 @@ export default function Recipe(props) {
         />
         <Text style={styles.title}>{title}</Text>
       </View>
-      // </TouchableOpacity>
     );
   }
 }

--- a/src/screens/Camera/index.js
+++ b/src/screens/Camera/index.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
-import { Text, View, TouchableOpacity, ActivityIndicator } from "react-native";
+import { Text, View, TouchableOpacity } from "react-native";
 import { Camera } from "expo-camera";
 import { useDispatch } from "react-redux";
 import { fetchLabels } from "../../store/labels/actions";
 import * as firebase from "firebase";
+import Loading from "../../components/Loading";
 
 export default function App({ navigation }) {
   const dispatch = useDispatch();
@@ -36,6 +37,7 @@ export default function App({ navigation }) {
         const imageUri = image.uri;
 
         if (imageUri) {
+          setLoading(true);
           this.uploadImage(imageUri, "test-image2")
             .then(() => {
               console.log("Success!");
@@ -66,7 +68,6 @@ export default function App({ navigation }) {
 
   //upload image to firebase
   uploadImage = async (uri, imageName) => {
-    setLoading(true);
     const response = await fetch(uri);
     const blob = await response.blob();
     const ref = firebase
@@ -77,19 +78,7 @@ export default function App({ navigation }) {
   };
 
   if (loading) {
-    return (
-      <View
-        style={{
-          flex: 1,
-          justifyContent: "center",
-          backgroundColor: "#5d3a00ff",
-        }}
-      >
-        <Text style={{ color: "#b3d89cff" }}>Niles: </Text>
-        <Text style={{ color: "#b3d89cff" }}>"Going as fast as I can.."</Text>
-        <ActivityIndicator size="large" color="#b3d89cff" />
-      </View>
-    );
+    return <Loading />;
   } else {
     return (
       <View style={{ flex: 1 }}>

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -1,14 +1,57 @@
-import React from "react";
-import { Text, View } from "react-native";
+import React, { useState } from "react";
+import { Text, View, FlatList, StyleSheet } from "react-native";
+import {
+  useFonts,
+  AlfaSlabOne_400Regular,
+} from "@expo-google-fonts/alfa-slab-one";
 
 export default function RecipeDetails({ route, navigation }) {
-  console.log("what is in details route", route);
-  const props = route.params;
+  const item = route.params;
+  const [details, setDetails] = useState([item]);
 
-  console.log("what is in props?", props);
+  const [fontsLoaded] = useFonts({
+    AlfaSlabOne_400Regular,
+  });
+
+  function MyHeader() {
+    return (
+      <View style={styles.header}>
+        <Text>I am the header!!!</Text>
+      </View>
+    );
+  }
+
+  function MyFooter() {
+    return (
+      <View>
+        <Text>I am the footer!!!</Text>
+      </View>
+    );
+  }
+
   return (
-    <View>
-      <Text>Hello detailts</Text>
-    </View>
+    <FlatList
+      ListHeaderComponent={MyHeader}
+      data={details}
+      renderItem={({ item }) => {
+        return (
+          <View>
+            <Text>I am in the middle, this is the title {item.title}</Text>
+          </View>
+        );
+      }}
+      keyExtractor={(item) => item.title + item.source}
+      ListFooterComponent={MyFooter}
+    />
   );
 }
+
+const styles = StyleSheet.create({
+  header: {
+    backgroundColor: "#a53f2bff",
+    width: "100%",
+    height: 100,
+    flexDirection: "row",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -14,6 +14,7 @@ import {
 } from "@expo-google-fonts/alfa-slab-one";
 import { Alata_400Regular } from "@expo-google-fonts/alata";
 import Hyperlink from "react-native-hyperlink";
+import { Table, Row, Rows } from "react-native-table-component";
 
 export default function RecipeDetails({ route, navigation }) {
   const item = route.params;
@@ -46,6 +47,75 @@ export default function RecipeDetails({ route, navigation }) {
           totalWeight,
         } = item;
 
+        const totalNutrientsArray = [
+          totalNutrients.ENERC_KCAL,
+          totalNutrients.CHOCDF,
+          totalNutrients.SUGAR,
+          totalNutrients.FAT,
+          totalNutrients.FASAT,
+          totalNutrients.FIBTG,
+          totalNutrients.PROCNT,
+          totalNutrients.NA,
+          totalNutrients.WATER,
+          totalNutrients.CA,
+          totalNutrients.CHOLE,
+          totalNutrients.FAMS,
+          totalNutrients.FAPU,
+          totalNutrients.FE,
+          totalNutrients.FOLAC,
+          totalNutrients.FOLDFE,
+          totalNutrients.FOLFD,
+          totalNutrients.K,
+          totalNutrients.MG,
+          totalNutrients.NIA,
+          totalNutrients.P,
+          totalNutrients.RIBF,
+          totalNutrients.THIA,
+          totalNutrients.TOCPHA,
+          totalNutrients.VITA_RAE,
+          totalNutrients.VITB12,
+          totalNutrients.VITB6A,
+          totalNutrients.VITC,
+          totalNutrients.VITD,
+          totalNutrients.VITK1,
+          totalNutrients.ZN,
+        ];
+
+        const totalDailyArray = [
+          totalDaily.ENERC_KCAL,
+          totalDaily.CHOCDF,
+          totalDaily.SUGAR,
+          totalDaily.FAT,
+          totalDaily.FASAT,
+          totalDaily.FIBTG,
+          totalDaily.PROCNT,
+          totalDaily.NA,
+          totalDaily.WATER,
+          totalDaily.CA,
+          totalDaily.CHOLE,
+          totalDaily.FAMS,
+          totalDaily.FAPU,
+          totalDaily.FE,
+          totalDaily.FOLAC,
+          totalDaily.FOLDFE,
+          totalDaily.FOLFD,
+          totalDaily.K,
+          totalDaily.MG,
+          totalDaily.NIA,
+          totalDaily.P,
+          totalDaily.RIBF,
+          totalDaily.THIA,
+          totalDaily.TOCPHA,
+          totalDaily.VITA_RAE,
+          totalDaily.VITB12,
+          totalDaily.VITB6A,
+          totalDaily.VITC,
+          totalDaily.VITD,
+          totalDaily.VITK1,
+          totalDaily.ZN,
+        ];
+
+        console.log("totaldailyarray", totalDailyArray);
         return (
           <View style={{ flex: 1 }} key={calories + totalTime}>
             <View style={styles.header}>
@@ -81,22 +151,20 @@ export default function RecipeDetails({ route, navigation }) {
                   }}
                   source={{ uri: image }}
                 />
-                <Text>Serves: {portion}</Text>
+                <Text>Portions: {portion}</Text>
 
                 <Text style={styles.middleText}>
                   Ingredients: {"\n\n"}
                   {item.ingredients.map((ingredient) => {
                     return (
                       <TouchableWithoutFeedback
+                        key={ingredient.text}
                         onPress={() => {
                           console.log("pressed");
                           setCheck(!check);
                         }}
                       >
-                        <Text
-                          style={{ flexDirection: "row" }}
-                          key={ingredient.text}
-                        >
+                        <Text style={{ flexDirection: "row" }}>
                           {!check ? (
                             <Image
                               style={{
@@ -117,23 +185,199 @@ export default function RecipeDetails({ route, navigation }) {
                 </Text>
 
                 {!moreInfo ? (
-                  <TouchableWithoutFeedback
-                    onPress={() => {
-                      setMoreInfo(true);
-                    }}
-                  >
-                    <Text>More information </Text>
-                  </TouchableWithoutFeedback>
-                ) : (
+                  //
+                  //
+                  //LESS INFORMATION
+                  //
+                  //
+
                   <View>
-                    <Text>
-                      {console.log("dietlabels", dietLabels)}{" "}
-                      {console.log("healthlabels", healthLabels)}{" "}
-                      {console.log("cautions", cautions)}{" "}
-                      {console.log("totalNutrients", totalNutrients)}{" "}
-                      {console.log("totalDaily", totalDaily)}{" "}
-                      {console.log("totalWeight", totalWeight)}{" "}
-                    </Text>
+                    <View style={styles.table}>
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopLeftRow}></View>
+
+                        {totalNutrientsArray.slice(0, 8).map((item) => {
+                          return (
+                            <View key={item.label} style={styles.tableLeftRow}>
+                              <Text style={styles.tableText}>{item.label}</Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopRow}>
+                          <Text style={styles.tableTopText}>
+                            per 100 gram:{"\n"}
+                          </Text>
+                        </View>
+
+                        {totalNutrientsArray.slice(0, 8).map((item) => {
+                          const number = 0.001;
+                          const amount = (
+                            (item.quantity / totalWeight) *
+                            100
+                          ).toFixed(2);
+
+                          return (
+                            <View key={item.label + 1} style={styles.tableRow}>
+                              <Text style={styles.tableText}>
+                                {amount === number.toFixed(2)
+                                  ? "-"
+                                  : amount + " " + item.unit}
+                              </Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopRow}>
+                          <Text style={styles.tableTopText}>
+                            per portion:{"\n"}(
+                            {Math.round(totalWeight / portion)} gram)
+                          </Text>
+                        </View>
+
+                        {totalNutrientsArray.slice(0, 8).map((item) => {
+                          const number = 0.001;
+                          const amount = (item.quantity / portion).toFixed(2);
+                          return (
+                            <View key={item.label + 2} style={styles.tableRow}>
+                              <Text style={styles.tableText}>
+                                {amount === number.toFixed(2)
+                                  ? "-"
+                                  : amount + " " + item.unit}
+                              </Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopRightRow}>
+                          <Text style={styles.tableTopText}>
+                            % D.V.{"\n"}(per portion)
+                          </Text>
+                        </View>
+
+                        {totalDailyArray.slice(0, 8).map((item) => {
+                          return item ? (
+                            <View key={item.label + 3} style={styles.tableRow}>
+                              <Text style={styles.tableText}>
+                                {item && (item.quantity / portion).toFixed(2)}{" "}
+                                {item.unit}
+                              </Text>
+                            </View>
+                          ) : (
+                            <View key={Math.random()} style={styles.tableRow}>
+                              <Text style={styles.tableText}>-</Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+                    </View>
+                    <TouchableWithoutFeedback
+                      onPress={() => {
+                        setMoreInfo(true);
+                      }}
+                    >
+                      <Text>More information </Text>
+                    </TouchableWithoutFeedback>
+                  </View>
+                ) : (
+                  //
+                  //
+                  // MORE INFORMATION
+                  //
+                  //
+
+                  <View style={{ width: "100%" }}>
+                    <View style={styles.table}>
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopLeftRow}></View>
+
+                        {totalNutrientsArray.map((item) => {
+                          return (
+                            <View key={item.label} style={styles.tableLeftRow}>
+                              <Text style={styles.tableText}>{item.label}</Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopRow}>
+                          <Text style={styles.tableTopText}>
+                            per 100 gram:{"\n"}
+                          </Text>
+                        </View>
+
+                        {totalNutrientsArray.map((item) => {
+                          const number = 0.001;
+                          const amount = (
+                            (item.quantity / totalWeight) *
+                            100
+                          ).toFixed(2);
+
+                          return (
+                            <View key={item.label + 1} style={styles.tableRow}>
+                              <Text style={styles.tableText}>
+                                {amount === number.toFixed(2)
+                                  ? "-"
+                                  : amount + " " + item.unit}
+                              </Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopRow}>
+                          <Text style={styles.tableTopText}>
+                            per portion:{"\n"}(
+                            {Math.round(totalWeight / portion)} gram)
+                          </Text>
+                        </View>
+
+                        {totalNutrientsArray.map((item) => {
+                          const number = 0.001;
+                          const amount = (item.quantity / portion).toFixed(2);
+                          return (
+                            <View key={item.label + 2} style={styles.tableRow}>
+                              <Text style={styles.tableText}>
+                                {amount === number.toFixed(2)
+                                  ? "-"
+                                  : amount + " " + item.unit}
+                              </Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+
+                      <View style={styles.tableColumn}>
+                        <View style={styles.tableTopRightRow}>
+                          <Text style={styles.tableTopText}>
+                            % D.V.{"\n"}(per portion)
+                          </Text>
+                        </View>
+
+                        {totalDailyArray.map((item) => {
+                          return item ? (
+                            <View key={item.label + 3} style={styles.tableRow}>
+                              <Text style={styles.tableText}>
+                                {item && (item.quantity / portion).toFixed(2)}{" "}
+                                {item.unit}
+                              </Text>
+                            </View>
+                          ) : (
+                            <View key={Math.random()} style={styles.tableRow}>
+                              <Text style={styles.tableText}>-</Text>
+                            </View>
+                          );
+                        })}
+                      </View>
+                    </View>
+
                     <TouchableWithoutFeedback
                       onPress={() => {
                         setMoreInfo(false);
@@ -152,23 +396,28 @@ export default function RecipeDetails({ route, navigation }) {
   );
 }
 
+const alfa = "AlfaSlabOne_400Regular";
+const alata = "Alata_400Regular";
+const green = "#b3d89cff";
+const red = "#a53f2bff";
+
 const styles = StyleSheet.create({
   header: {
-    backgroundColor: "#a53f2bff",
+    backgroundColor: red,
     width: "100%",
     height: 100,
     flexDirection: "column",
     justifyContent: "center",
   },
   headerText: {
-    color: "#b3d89cff",
+    color: green,
     fontSize: 100,
     fontFamily: "AlfaSlabOne_400Regular",
     paddingHorizontal: 20,
     textAlign: "center",
   },
   middle: {
-    backgroundColor: "#b3d89cff",
+    backgroundColor: green,
     justifyContent: "center",
     width: "100%",
     height: "100%",
@@ -178,5 +427,69 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontFamily: "Alata_400Regular",
     paddingHorizontal: 10,
+  },
+
+  table: {
+    flexDirection: "row",
+    alignSelf: "center",
+    marginVertical: 10,
+  },
+
+  tableColumn: {
+    borderTopWidth: 5,
+    borderBottomWidth: 5,
+    borderColor: red,
+  },
+  tableTopLeftRow: {
+    borderRightColor: green,
+    borderLeftColor: red,
+    borderBottomColor: red,
+    backgroundColor: red,
+    width: 150,
+    height: 50,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    borderLeftWidth: 2,
+    padding: 3,
+  },
+  tableTopRightRow: {
+    borderColor: red,
+    backgroundColor: red,
+    height: 50,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    padding: 3,
+  },
+  tableTopRow: {
+    borderBottomColor: red,
+    borderRightColor: green,
+    backgroundColor: red,
+    height: 50,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    padding: 3,
+  },
+  tableLeftRow: {
+    borderColor: red,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    borderLeftWidth: 2,
+    padding: 3,
+  },
+  tableRow: {
+    borderColor: red,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    padding: 3,
+  },
+  tableTopText: {
+    fontSize: 12.5,
+    fontFamily: "Alata_400Regular",
+    color: green,
+  },
+  tableText: {
+    fontSize: 12.5,
+    fontFamily: "Alata_400Regular",
+    color: red,
   },
 });

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -16,6 +16,16 @@ import { Alata_400Regular } from "@expo-google-fonts/alata";
 import Hyperlink from "react-native-hyperlink";
 import { Table, Row, Rows } from "react-native-table-component";
 
+const Alfa = "AlfaSlabOne_400Regular";
+const Alata = "Alata_400Regular";
+const green = "#b3d89cff";
+const darkGreen = "#70B247";
+const lightGreen = "#C9EBB4";
+const red = "#a53f2bff";
+const blue = "#3b7080ff";
+const lightBlue = "#57AFCA";
+const salmon = "#f79f79ff";
+
 export default function RecipeDetails({ route, navigation }) {
   const item = route.params;
   const [details, setDetails] = useState([item]);
@@ -27,7 +37,6 @@ export default function RecipeDetails({ route, navigation }) {
     Alata_400Regular,
   });
 
-  console.log("check", check);
   return (
     <View style={{ flex: 1, backgroundColor: "#b3d89cff" }}>
       {details.map((item) => {
@@ -115,7 +124,41 @@ export default function RecipeDetails({ route, navigation }) {
           totalDaily.ZN,
         ];
 
-        console.log("totaldailyarray", totalDailyArray);
+        const number = (0.001).toFixed(2);
+
+        function renderAmount(item, amount) {
+          if (!item.quantity) {
+            return "-";
+          } else if (item.quantity && amount === number) {
+            return `< 0,01${item.unit}`;
+          } else {
+            return amount + " " + item.unit;
+          }
+        }
+
+        function renderLabels(array, color) {
+          return array.map((label) => {
+            return (
+              <View
+                key={label}
+                style={{
+                  backgroundColor: color,
+                  padding: 10,
+                  borderRadius: 25,
+                  marginTop: 10,
+                  marginLeft: 10,
+                }}
+              >
+                <Text
+                  style={{ color: lightGreen, fontFamily: Alata, fontSize: 12 }}
+                >
+                  {label}
+                </Text>
+              </View>
+            );
+          });
+        }
+
         return (
           <View style={{ flex: 1 }} key={calories + totalTime}>
             <View style={styles.header}>
@@ -129,18 +172,20 @@ export default function RecipeDetails({ route, navigation }) {
               <Hyperlink
                 linkDefault
                 linkStyle={{
-                  color: "#2980b9",
+                  color: lightBlue,
                   fontSize: 20,
+                  textDecorationLine: "underline",
                 }}
-                linkText={(url) =>
-                  url === sourceUrl ? `Read more on ${source}!` : url
-                }
+                linkText={(url) => (url === sourceUrl ? source : url)}
               >
-                <Text style={{ fontSize: 18, textAlign: "center" }}>
-                  {sourceUrl}
+                <Text
+                  style={{ fontSize: 18, textAlign: "center", color: green }}
+                >
+                  Read full recipe on {sourceUrl}!
                 </Text>
               </Hyperlink>
             </View>
+
             <ScrollView>
               <View style={styles.middle}>
                 <Image
@@ -151,14 +196,31 @@ export default function RecipeDetails({ route, navigation }) {
                   }}
                   source={{ uri: image }}
                 />
-                <Text>Portions: {portion}</Text>
 
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "flex-start",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  {renderLabels(dietLabels, blue)}
+                  {renderLabels(healthLabels, darkGreen)}
+                  {renderLabels(cautions, salmon)}
+                </View>
+
+                <Text style={styles.middleTextCenter}>
+                  Ingredients for {portion}{" "}
+                  {portion === 1 ? "portion" : "portions"}:
+                </Text>
                 <Text style={styles.middleText}>
-                  Ingredients: {"\n\n"}
                   {item.ingredients.map((ingredient) => {
+                    console.log("what is ingredietn", ingredient);
                     return (
                       <TouchableWithoutFeedback
-                        key={ingredient.text}
+                        key={
+                          ingredient.text + ingredient.weight + ingredient.image
+                        }
                         onPress={() => {
                           console.log("pressed");
                           setCheck(!check);
@@ -184,6 +246,7 @@ export default function RecipeDetails({ route, navigation }) {
                   })}
                 </Text>
 
+                <Text style={styles.middleTextCenter}>Nutritional values:</Text>
                 {!moreInfo ? (
                   //
                   //
@@ -194,7 +257,11 @@ export default function RecipeDetails({ route, navigation }) {
                   <View>
                     <View style={styles.table}>
                       <View style={styles.tableColumn}>
-                        <View style={styles.tableTopLeftRow}></View>
+                        <View style={styles.tableTopLeftRow}>
+                          <Text style={styles.tableTopText}>
+                            Nutritional {"\n"} value per:
+                          </Text>
+                        </View>
 
                         {totalNutrientsArray.slice(0, 8).map((item) => {
                           return (
@@ -206,13 +273,10 @@ export default function RecipeDetails({ route, navigation }) {
                       </View>
                       <View style={styles.tableColumn}>
                         <View style={styles.tableTopRow}>
-                          <Text style={styles.tableTopText}>
-                            per 100 gram:{"\n"}
-                          </Text>
+                          <Text style={styles.tableTopText}>100 gram:</Text>
                         </View>
 
                         {totalNutrientsArray.slice(0, 8).map((item) => {
-                          const number = 0.001;
                           const amount = (
                             (item.quantity / totalWeight) *
                             100
@@ -221,9 +285,7 @@ export default function RecipeDetails({ route, navigation }) {
                           return (
                             <View key={item.label + 1} style={styles.tableRow}>
                               <Text style={styles.tableText}>
-                                {amount === number.toFixed(2)
-                                  ? "-"
-                                  : amount + " " + item.unit}
+                                {renderAmount(item, amount)}
                               </Text>
                             </View>
                           );
@@ -233,20 +295,17 @@ export default function RecipeDetails({ route, navigation }) {
                       <View style={styles.tableColumn}>
                         <View style={styles.tableTopRow}>
                           <Text style={styles.tableTopText}>
-                            per portion:{"\n"}(
-                            {Math.round(totalWeight / portion)} gram)
+                            portion of{"\n"}
+                            {Math.round(totalWeight / portion)} gram:
                           </Text>
                         </View>
 
                         {totalNutrientsArray.slice(0, 8).map((item) => {
-                          const number = 0.001;
                           const amount = (item.quantity / portion).toFixed(2);
                           return (
                             <View key={item.label + 2} style={styles.tableRow}>
                               <Text style={styles.tableText}>
-                                {amount === number.toFixed(2)
-                                  ? "-"
-                                  : amount + " " + item.unit}
+                                {renderAmount(item, amount)}
                               </Text>
                             </View>
                           );
@@ -263,10 +322,14 @@ export default function RecipeDetails({ route, navigation }) {
                         {totalDailyArray.slice(0, 8).map((item) => {
                           return item ? (
                             <View key={item.label + 3} style={styles.tableRow}>
-                              <Text style={styles.tableText}>
-                                {item && (item.quantity / portion).toFixed(2)}{" "}
-                                {item.unit}
-                              </Text>
+                              {item && item.quantity.toFixed(2) === number ? (
+                                <Text style={styles.tableText}> - </Text>
+                              ) : (
+                                <Text style={styles.tableText}>
+                                  {(item.quantity / portion).toFixed(2)}{" "}
+                                  {item.unit}
+                                </Text>
+                              )}
                             </View>
                           ) : (
                             <View key={Math.random()} style={styles.tableRow}>
@@ -281,7 +344,9 @@ export default function RecipeDetails({ route, navigation }) {
                         setMoreInfo(true);
                       }}
                     >
-                      <Text>More information </Text>
+                      <Text style={styles.middleTextCenter}>
+                        More information{" "}
+                      </Text>
                     </TouchableWithoutFeedback>
                   </View>
                 ) : (
@@ -294,7 +359,11 @@ export default function RecipeDetails({ route, navigation }) {
                   <View style={{ width: "100%" }}>
                     <View style={styles.table}>
                       <View style={styles.tableColumn}>
-                        <View style={styles.tableTopLeftRow}></View>
+                        <View style={styles.tableTopLeftRow}>
+                          <Text style={styles.tableTopText}>
+                            Nutritional {"\n"} value per:
+                          </Text>
+                        </View>
 
                         {totalNutrientsArray.map((item) => {
                           return (
@@ -307,13 +376,10 @@ export default function RecipeDetails({ route, navigation }) {
 
                       <View style={styles.tableColumn}>
                         <View style={styles.tableTopRow}>
-                          <Text style={styles.tableTopText}>
-                            per 100 gram:{"\n"}
-                          </Text>
+                          <Text style={styles.tableTopText}>100 gram:</Text>
                         </View>
 
                         {totalNutrientsArray.map((item) => {
-                          const number = 0.001;
                           const amount = (
                             (item.quantity / totalWeight) *
                             100
@@ -322,9 +388,7 @@ export default function RecipeDetails({ route, navigation }) {
                           return (
                             <View key={item.label + 1} style={styles.tableRow}>
                               <Text style={styles.tableText}>
-                                {amount === number.toFixed(2)
-                                  ? "-"
-                                  : amount + " " + item.unit}
+                                {renderAmount(item, amount)}
                               </Text>
                             </View>
                           );
@@ -334,20 +398,17 @@ export default function RecipeDetails({ route, navigation }) {
                       <View style={styles.tableColumn}>
                         <View style={styles.tableTopRow}>
                           <Text style={styles.tableTopText}>
-                            per portion:{"\n"}(
-                            {Math.round(totalWeight / portion)} gram)
+                            portion of{"\n"}
+                            {Math.round(totalWeight / portion)} gram:
                           </Text>
                         </View>
 
                         {totalNutrientsArray.map((item) => {
-                          const number = 0.001;
                           const amount = (item.quantity / portion).toFixed(2);
                           return (
                             <View key={item.label + 2} style={styles.tableRow}>
                               <Text style={styles.tableText}>
-                                {amount === number.toFixed(2)
-                                  ? "-"
-                                  : amount + " " + item.unit}
+                                {renderAmount(item, amount)}
                               </Text>
                             </View>
                           );
@@ -364,10 +425,14 @@ export default function RecipeDetails({ route, navigation }) {
                         {totalDailyArray.map((item) => {
                           return item ? (
                             <View key={item.label + 3} style={styles.tableRow}>
-                              <Text style={styles.tableText}>
-                                {item && (item.quantity / portion).toFixed(2)}{" "}
-                                {item.unit}
-                              </Text>
+                              {item && item.quantity.toFixed(2) === number ? (
+                                <Text style={styles.tableText}> - </Text>
+                              ) : (
+                                <Text style={styles.tableText}>
+                                  {(item.quantity / portion).toFixed(2)}{" "}
+                                  {item.unit}
+                                </Text>
+                              )}
                             </View>
                           ) : (
                             <View key={Math.random()} style={styles.tableRow}>
@@ -383,7 +448,9 @@ export default function RecipeDetails({ route, navigation }) {
                         setMoreInfo(false);
                       }}
                     >
-                      <Text>Less info</Text>
+                      <Text style={styles.middleTextCenter}>
+                        Less information
+                      </Text>
                     </TouchableWithoutFeedback>
                   </View>
                 )}
@@ -396,11 +463,6 @@ export default function RecipeDetails({ route, navigation }) {
   );
 }
 
-const alfa = "AlfaSlabOne_400Regular";
-const alata = "Alata_400Regular";
-const green = "#b3d89cff";
-const red = "#a53f2bff";
-
 const styles = StyleSheet.create({
   header: {
     backgroundColor: red,
@@ -410,9 +472,9 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   headerText: {
-    color: green,
+    color: darkGreen,
     fontSize: 100,
-    fontFamily: "AlfaSlabOne_400Regular",
+    fontFamily: Alfa,
     paddingHorizontal: 20,
     textAlign: "center",
   },
@@ -423,12 +485,18 @@ const styles = StyleSheet.create({
     height: "100%",
   },
   middleText: {
-    color: "white",
+    color: red,
     fontSize: 20,
-    fontFamily: "Alata_400Regular",
+    fontFamily: Alata,
     paddingHorizontal: 10,
   },
-
+  middleTextCenter: {
+    color: red,
+    fontSize: 25,
+    fontFamily: Alata,
+    textAlign: "center",
+    marginBottom: 10,
+  },
   table: {
     flexDirection: "row",
     alignSelf: "center",
@@ -484,12 +552,12 @@ const styles = StyleSheet.create({
   },
   tableTopText: {
     fontSize: 12.5,
-    fontFamily: "Alata_400Regular",
+    fontFamily: Alata,
     color: green,
   },
   tableText: {
     fontSize: 12.5,
-    fontFamily: "Alata_400Regular",
+    fontFamily: Alata,
     color: red,
   },
 });

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+export default function RecipeDetails({ route, navigation }) {
+  console.log("what is in details route", route);
+  const props = route.params;
+
+  console.log("what is in props?", props);
+  return (
+    <View>
+      <Text>Hello detailts</Text>
+    </View>
+  );
+}

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   ActivityIndicator,
   TouchableWithoutFeedback,
+  ImageBackground,
 } from "react-native";
 import {
   useFonts,
@@ -14,7 +15,6 @@ import {
 } from "@expo-google-fonts/alfa-slab-one";
 import { Alata_400Regular } from "@expo-google-fonts/alata";
 import Hyperlink from "react-native-hyperlink";
-import { Table, Row, Rows } from "react-native-table-component";
 
 const Alfa = "AlfaSlabOne_400Regular";
 const Alata = "Alata_400Regular";
@@ -30,12 +30,45 @@ export default function RecipeDetails({ route, navigation }) {
   const item = route.params;
   const [details, setDetails] = useState([item]);
   const [check, setCheck] = useState(false);
+  const [ingredientLines, setIngredientLines] = useState({});
   const [moreInfo, setMoreInfo] = useState(false);
 
   const [fontsLoaded] = useFonts({
     AlfaSlabOne_400Regular,
     Alata_400Regular,
   });
+
+  useEffect(() => {
+    const items = item.ingredients.map((ingredient) => {
+      return ingredient.text;
+    });
+
+    console.log("what is items here?", items);
+
+    const object = items.reduce(
+      (a, key) => Object.assign(a, { [key]: false }),
+      {}
+    );
+
+    console.log("what is obejct", object);
+
+    setIngredientLines(object);
+
+    // const what = items.map((i) => {
+    //   if(Object.prototype.hasOwnProperty.call(object, i)){
+
+    //   }
+    // });
+
+    // console.log("what is whatttttttt", what);
+
+    // for (const [key, value] of Object.entries(object)) {
+    //   setIngredientLines([...ingredientLines, { [key]: value }]);
+    //   console.log(`what is going on here! ${key}: ${value}`);
+    // }
+  }, [item]);
+
+  console.log("what is ingredientlines", ingredientLines);
 
   return (
     <View style={{ flex: 1, backgroundColor: "#b3d89cff" }}>
@@ -54,6 +87,7 @@ export default function RecipeDetails({ route, navigation }) {
           totalNutrients,
           totalDaily,
           totalWeight,
+          ingredients,
         } = item;
 
         const totalNutrientsArray = [
@@ -213,9 +247,16 @@ export default function RecipeDetails({ route, navigation }) {
                   Ingredients for {portion}{" "}
                   {portion === 1 ? "portion" : "portions"}:
                 </Text>
-                <Text style={styles.middleText}>
-                  {item.ingredients.map((ingredient) => {
-                    console.log("what is ingredietn", ingredient);
+                <View>
+                  {ingredients.map((ingredient) => {
+                    const image = ingredient.image
+                      ? { uri: ingredient.image }
+                      : require("../../images/placeholder.png");
+                    const thisIngredientLine = ingredient.text;
+
+                    const thisthing = ingredientLines[thisIngredientLine];
+                    console.log("what is thisthing", thisthing);
+
                     return (
                       <TouchableWithoutFeedback
                         key={
@@ -224,27 +265,80 @@ export default function RecipeDetails({ route, navigation }) {
                         onPress={() => {
                           console.log("pressed");
                           setCheck(!check);
+                          ingredientLines[thisIngredientLine] === false
+                            ? setIngredientLines({
+                                ...ingredientLines,
+                                [thisIngredientLine]: true,
+                              })
+                            : setIngredientLines({
+                                ...ingredientLines,
+                                [thisIngredientLine]: false,
+                              });
                         }}
                       >
-                        <Text style={{ flexDirection: "row" }}>
-                          {!check ? (
-                            <Image
-                              style={{
-                                width: 40,
-                                height: 40,
-                              }}
-                              source={{ uri: ingredient.image }}
-                            />
-                          ) : (
-                            <Text>[GOTIT]</Text>
-                          )}
-                          -{ingredient.text}
-                          {"\n"}
-                        </Text>
+                        <View style={{ flexDirection: "row" }}>
+                          <View style={{ flexDirection: "column", flex: 8 }}>
+                            <Text
+                              style={
+                                ingredientLines[thisIngredientLine] === false
+                                  ? {
+                                      color: red,
+                                      fontSize: 20,
+                                      fontFamily: Alata,
+                                      paddingHorizontal: 10,
+                                    }
+                                  : {
+                                      color: red,
+                                      fontSize: 20,
+                                      fontFamily: Alata,
+                                      paddingHorizontal: 10,
+                                      textDecorationLine: "line-through",
+                                    }
+                              }
+                            >
+                              -{ingredient.text}
+                            </Text>
+                          </View>
+                          <View style={{ flexDirection: "column", flex: 1 }}>
+                            {ingredientLines[thisIngredientLine] === false ? (
+                              <Image
+                                style={{
+                                  width: 40,
+                                  height: 40,
+                                }}
+                                source={image}
+                              />
+                            ) : (
+                              <View style={{ width: 40, height: 40 }}>
+                                <ImageBackground
+                                  style={{
+                                    resizeMode: "cover",
+                                    justifyContent: "center",
+                                    flex: 1,
+                                    opacity: 0.5,
+                                  }}
+                                  source={image}
+                                >
+                                  <Text
+                                    style={{
+                                      color: red,
+                                      fontSize: 30,
+                                      fontFamily: Alata,
+                                      paddingHorizontal: 10,
+                                      textAlign: "center",
+                                    }}
+                                  >
+                                    {"\u2713"}
+                                  </Text>
+                                </ImageBackground>
+                              </View>
+                            )}
+                          </View>
+                        </View>
                       </TouchableWithoutFeedback>
                     );
                   })}
-                </Text>
+                </View>
 
                 <Text style={styles.middleTextCenter}>Nutritional values:</Text>
                 {!moreInfo ? (

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -1,48 +1,154 @@
-import React, { useState } from "react";
-import { Text, View, FlatList, StyleSheet } from "react-native";
+import React, { useState, useEffect } from "react";
+import {
+  Text,
+  View,
+  Image,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableWithoutFeedback,
+} from "react-native";
 import {
   useFonts,
   AlfaSlabOne_400Regular,
 } from "@expo-google-fonts/alfa-slab-one";
+import { Alata_400Regular } from "@expo-google-fonts/alata";
+import Hyperlink from "react-native-hyperlink";
 
 export default function RecipeDetails({ route, navigation }) {
   const item = route.params;
   const [details, setDetails] = useState([item]);
+  const [check, setCheck] = useState(false);
+  const [moreInfo, setMoreInfo] = useState(false);
 
   const [fontsLoaded] = useFonts({
     AlfaSlabOne_400Regular,
+    Alata_400Regular,
   });
 
-  function MyHeader() {
-    return (
-      <View style={styles.header}>
-        <Text>I am the header!!!</Text>
-      </View>
-    );
-  }
-
-  function MyFooter() {
-    return (
-      <View>
-        <Text>I am the footer!!!</Text>
-      </View>
-    );
-  }
-
+  console.log("check", check);
   return (
-    <FlatList
-      ListHeaderComponent={MyHeader}
-      data={details}
-      renderItem={({ item }) => {
+    <View style={{ flex: 1, backgroundColor: "#b3d89cff" }}>
+      {details.map((item) => {
+        const {
+          image,
+          title,
+          source,
+          sourceUrl,
+          portion,
+          dietLabels,
+          healthLabels,
+          cautions,
+          calories,
+          totalTime,
+          totalNutrients,
+          totalDaily,
+          totalWeight,
+        } = item;
+
         return (
-          <View>
-            <Text>I am in the middle, this is the title {item.title}</Text>
+          <View style={{ flex: 1 }} key={calories + totalTime}>
+            <View style={styles.header}>
+              <Text
+                adjustsFontSizeToFit={true}
+                numberOfLines={1}
+                style={styles.headerText}
+              >
+                {title}
+              </Text>
+              <Hyperlink
+                linkDefault
+                linkStyle={{
+                  color: "#2980b9",
+                  fontSize: 20,
+                }}
+                linkText={(url) =>
+                  url === sourceUrl ? `Read more on ${source}!` : url
+                }
+              >
+                <Text style={{ fontSize: 18, textAlign: "center" }}>
+                  {sourceUrl}
+                </Text>
+              </Hyperlink>
+            </View>
+            <ScrollView>
+              <View style={styles.middle}>
+                <Image
+                  style={{
+                    width: "100%",
+                    height: 400,
+                    alignSelf: "center",
+                  }}
+                  source={{ uri: image }}
+                />
+                <Text>Serves: {portion}</Text>
+
+                <Text style={styles.middleText}>
+                  Ingredients: {"\n\n"}
+                  {item.ingredients.map((ingredient) => {
+                    return (
+                      <TouchableWithoutFeedback
+                        onPress={() => {
+                          console.log("pressed");
+                          setCheck(!check);
+                        }}
+                      >
+                        <Text
+                          style={{ flexDirection: "row" }}
+                          key={ingredient.text}
+                        >
+                          {!check ? (
+                            <Image
+                              style={{
+                                width: 40,
+                                height: 40,
+                              }}
+                              source={{ uri: ingredient.image }}
+                            />
+                          ) : (
+                            <Text>[GOTIT]</Text>
+                          )}
+                          -{ingredient.text}
+                          {"\n"}
+                        </Text>
+                      </TouchableWithoutFeedback>
+                    );
+                  })}
+                </Text>
+
+                {!moreInfo ? (
+                  <TouchableWithoutFeedback
+                    onPress={() => {
+                      setMoreInfo(true);
+                    }}
+                  >
+                    <Text>More information </Text>
+                  </TouchableWithoutFeedback>
+                ) : (
+                  <View>
+                    <Text>
+                      {console.log("dietlabels", dietLabels)}{" "}
+                      {console.log("healthlabels", healthLabels)}{" "}
+                      {console.log("cautions", cautions)}{" "}
+                      {console.log("totalNutrients", totalNutrients)}{" "}
+                      {console.log("totalDaily", totalDaily)}{" "}
+                      {console.log("totalWeight", totalWeight)}{" "}
+                    </Text>
+                    <TouchableWithoutFeedback
+                      onPress={() => {
+                        setMoreInfo(false);
+                      }}
+                    >
+                      <Text>Less info</Text>
+                    </TouchableWithoutFeedback>
+                  </View>
+                )}
+              </View>
+            </ScrollView>
           </View>
         );
-      }}
-      keyExtractor={(item) => item.title + item.source}
-      ListFooterComponent={MyFooter}
-    />
+      })}
+    </View>
   );
 }
 
@@ -51,7 +157,26 @@ const styles = StyleSheet.create({
     backgroundColor: "#a53f2bff",
     width: "100%",
     height: 100,
-    flexDirection: "row",
+    flexDirection: "column",
     justifyContent: "center",
+  },
+  headerText: {
+    color: "#b3d89cff",
+    fontSize: 100,
+    fontFamily: "AlfaSlabOne_400Regular",
+    paddingHorizontal: 20,
+    textAlign: "center",
+  },
+  middle: {
+    backgroundColor: "#b3d89cff",
+    justifyContent: "center",
+    width: "100%",
+    height: "100%",
+  },
+  middleText: {
+    color: "white",
+    fontSize: 20,
+    fontFamily: "Alata_400Regular",
+    paddingHorizontal: 10,
   },
 });

--- a/src/screens/Recipes/index.js
+++ b/src/screens/Recipes/index.js
@@ -5,7 +5,8 @@ import {
   View,
   ImageBackground,
   Button,
-  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
   FlatList,
 } from "react-native";
 import { selectRecipes } from "../../store/recipes/selectors";
@@ -23,25 +24,31 @@ export default function Recipes({ route, navigation }) {
         data={recipes}
         numColumns={2}
         renderItem={({ item }) => {
+          const props = [item.title, item.image, item.source];
+
           return (
-            <Recipe
-              key={item.title}
-              title={item.title}
-              image={item.image}
-              source={item.source}
-              sourceUrl={item.sourceUrl}
-              portion={item.portion}
-              dietLabels={item.dietLabels}
-              healthLabels={item.healthLabels}
-              cautions={item.cautions}
-              text={item.text}
-              ingredients={item.ingredients}
-              calories={item.calories}
-              totalTime={item.totalTime}
-              totalNutrients={item.totalNutrients}
-              totalDaily={item.totalDaily}
-              totalWeight={item.totalWeight}
-            />
+            <TouchableOpacity
+              style={styles.touch}
+              onPress={() => navigation.navigate("RecipeDetails", props)}
+            >
+              <Recipe
+                title={item.title}
+                image={item.image}
+                source={item.source}
+                sourceUrl={item.sourceUrl}
+                portion={item.portion}
+                dietLabels={item.dietLabels}
+                healthLabels={item.healthLabels}
+                cautions={item.cautions}
+                text={item.text}
+                ingredients={item.ingredients}
+                calories={item.calories}
+                totalTime={item.totalTime}
+                totalNutrients={item.totalNutrients}
+                totalDaily={item.totalDaily}
+                totalWeight={item.totalWeight}
+              />
+            </TouchableOpacity>
           );
         }}
         keyExtractor={(item) => item.title + item.source}
@@ -49,3 +56,7 @@ export default function Recipes({ route, navigation }) {
     );
   }
 }
+
+const styles = StyleSheet.create({
+  touch: { backgroundColor: "#b3d89cff", width: "50%" },
+});

--- a/src/screens/Recipes/index.js
+++ b/src/screens/Recipes/index.js
@@ -5,7 +5,7 @@ import { selectRecipes } from "../../store/recipes/selectors";
 import Recipe from "../../components/Recipe";
 import Loading from "../../components/Loading";
 
-export default function Recipes({ navigation }) {
+export default function Recipes({ route, navigation }) {
   const recipes = useSelector(selectRecipes);
 
   if (!recipes) {

--- a/src/screens/Recipes/index.js
+++ b/src/screens/Recipes/index.js
@@ -1,35 +1,25 @@
-import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import {
-  Text,
-  View,
-  ImageBackground,
-  Button,
-  StyleSheet,
-  TouchableOpacity,
-  FlatList,
-} from "react-native";
+import React from "react";
+import { useSelector } from "react-redux";
+import { StyleSheet, TouchableOpacity, FlatList } from "react-native";
 import { selectRecipes } from "../../store/recipes/selectors";
 import Recipe from "../../components/Recipe";
-import { AppLoading } from "expo";
+import Loading from "../../components/Loading";
 
-export default function Recipes({ route, navigation }) {
+export default function Recipes({ navigation }) {
   const recipes = useSelector(selectRecipes);
 
   if (!recipes) {
-    return <AppLoading />;
+    return <Loading />;
   } else {
     return (
       <FlatList
         data={recipes}
         numColumns={2}
         renderItem={({ item }) => {
-          const props = [item.title, item.image, item.source];
-
           return (
             <TouchableOpacity
               style={styles.touch}
-              onPress={() => navigation.navigate("RecipeDetails", props)}
+              onPress={() => navigation.navigate("RecipeDetails", item)}
             >
               <Recipe
                 title={item.title}

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -1,17 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Text,
   View,
-  ImageBackground,
   Button,
   Image,
   ScrollView,
+  ActivityIndicator,
 } from "react-native";
-import * as firebase from "firebase";
 import { useDispatch, useSelector } from "react-redux";
 import { getRecipes } from "../../store/recipes/actions";
 import { selectLabels } from "../../store/labels/selectors";
-import { AppLoading } from "expo";
 
 export default function index({ route, navigation }) {
   const imageUri = route.params;
@@ -43,9 +41,9 @@ export default function index({ route, navigation }) {
         }}
       >
         <Text>Please select the label that fits your product best!</Text>
-        <ScrollView horizontal={true} showsHorizontalScrollIndicator={false}>
-          {labels ? (
-            labels.map((label) => {
+        {labels ? (
+          <ScrollView horizontal={true} showsHorizontalScrollIndicator={false}>
+            {labels.map((label) => {
               return (
                 <View
                   key={label + Math.random()}
@@ -59,11 +57,11 @@ export default function index({ route, navigation }) {
                   />
                 </View>
               );
-            })
-          ) : (
-            <AppLoading />
-          )}
-        </ScrollView>
+            })}
+          </ScrollView>
+        ) : (
+          <ActivityIndicator />
+        )}
 
         <View
           style={{


### PR DESCRIPTION
For this feature I added the ability to click on a recipe, which will send you to that recipe's details page. 

Here I added a scrollview, so you can scroll through the information. While rendering this page, I found out to my surprise that there are no instructions on how to make the recipes in this recipe API. I am guessing it has something to do with copyright. Since there is a link to the original recipe, I also added that to the page. 

The input for the nutritional information table is of course dynamically set. The most important information shows first, if you click on more information, you see a bigger list.

I also added the labels to the recipe's details, something you would be able to search for in a later version of the app.

Since I also wanted to add some kind of shopping list to this app, for this skateboard version, I added the ability to click on the ingredient (line) to cross it off. So now (if you keep this page open), you will be able use this list as a shopping list.