### PR TITLE
Feat barcode scanner

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import store from "./src/store";
 import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 import HomeScreen from "./src/screens/HomeScreen";
+import BarcodeScanner from "./src/screens/BarcodeScanner";
 import Camera from "./src/screens/Camera";
 import Preview from "./src/screens/Preview";
 import Recipes from "./src/screens/Recipes";
@@ -33,6 +34,7 @@ function App() {
       <NavigationContainer>
         <Stack.Navigator screenOptions={{ headerShown: false }}>
           <Stack.Screen name="HomeScreen" component={HomeScreen} />
+          <Stack.Screen name="BarcodeScanner" component={BarcodeScanner} />
           <Stack.Screen name="Camera" component={Camera} />
           <Stack.Screen name="Preview" component={Preview} />
           <Stack.Screen name="Recipes" component={Recipes} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -3495,6 +3495,15 @@
         "url-parse": "^1.4.4"
       }
     },
+    "expo-barcode-scanner": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-8.2.1.tgz",
+      "integrity": "sha512-cmsXLoWThqYtfWpsFOg7KCLgJsYOHbj9LG1wpFG86xSdJlQrfZRQ1GzrA4eT06rp8FdGs9nLJPh8/10AH9EZoA==",
+      "requires": {
+        "lodash": "^4.6.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "expo-camera": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-8.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-native-web": "~0.11.7",
     "react-redux": "^7.2.1",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "expo-barcode-scanner": "~8.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/src/colours/index.js
+++ b/src/colours/index.js
@@ -1,0 +1,19 @@
+export const lightGreen = "#C9EBB4";
+export const green = "#b3d89c";
+export const darkGreen = "#70B247";
+
+export const lightBlue = "#57AFCA";
+export const blue = "#3b7080";
+export const darkBlue = "#284C57";
+
+export const lightSalmon = "#FBBCA0";
+export const salmon = "#f79f79";
+export const darkSalmon = "#E84F0E";
+
+export const lightBrown = "#DD8900";
+export const brown = "#5d3a00";
+export const darkBrown = "#3E2600";
+
+export const lightRed = "#DF6750";
+export const red = "#a53f2b";
+export const darkRed = "#6F2A1D";

--- a/src/components/Recipe/index.js
+++ b/src/components/Recipe/index.js
@@ -11,23 +11,7 @@ export default function Recipe(props) {
     AlfaSlabOne_400Regular,
   });
 
-  const {
-    title,
-    image,
-    source,
-    sourceUrl,
-    portion,
-    dietLabels,
-    healthLabels,
-    cautions,
-    text,
-    ingredients,
-    calories,
-    totalTime,
-    totalNutrients,
-    totalDaily,
-    totalWeight,
-  } = props;
+  const { title, image } = props;
 
   if (!fontsLoaded) {
     return <ActivityIndicator color="#a53f2bff" />;

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -15,6 +15,7 @@ import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
 
 export default function BarcodeScanner({ navigation }) {
   const imageUri = useSelector(selectUrl);
+  console.log("is the imageUri here in barcodescanner?", imageUri);
   const checkUrl = imageUri && imageUri.split(":");
   const dispatch = useDispatch();
   useFonts({ Alata_400Regular });
@@ -36,9 +37,14 @@ export default function BarcodeScanner({ navigation }) {
   };
 
   useEffect(() => {
+    console.log("what is checkURL??", checkUrl);
     if (scanned && checkUrl && checkUrl[0] === "https") {
       setScanned(false);
-      navigation.navigate("Preview", imageUri);
+      console.log(
+        "what do we have here before navigating to preview?",
+        imageUri
+      );
+      navigation.navigate("Preview", { imageUri });
     }
   }, [imageUri]);
 

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -1,11 +1,20 @@
 import React, { useState, useEffect } from "react";
-import { Text, View, StyleSheet, Button } from "react-native";
+import {
+  Text,
+  View,
+  StyleSheet,
+  Button,
+  TouchableHighlight,
+} from "react-native";
 import { BarCodeScanner } from "expo-barcode-scanner";
-import { blue, lightBrown } from "../../colours";
+import { blue, lightBrown, lightBlue } from "../../colours";
+import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
 
 export default function BarcodeScanner() {
+  useFonts({ Alata_400Regular });
   const [hasPermission, setHasPermission] = useState(null);
   const [scanned, setScanned] = useState(false);
+  const [fontColor, setFontColor] = useState(lightBrown);
 
   useEffect(() => {
     (async () => {
@@ -26,18 +35,24 @@ export default function BarcodeScanner() {
     return <Text>No access to camera</Text>;
   }
 
+  console.log("fontcolor", fontColor);
+
   return (
     <View
       style={{
         flex: 1,
         flexDirection: "column",
         backgroundColor: blue,
+        justifyContent: "space-between",
       }}
     >
       <Text
         style={{
           textAlign: "center",
           color: lightBrown,
+          fontFamily: "Alata_400Regular",
+          fontSize: 35,
+          marginTop: 25,
         }}
       >
         Aim at the barcode!
@@ -48,7 +63,32 @@ export default function BarcodeScanner() {
       />
 
       {scanned && (
-        <Button title={"Tap to Scan Again"} onPress={() => setScanned(false)} />
+        <TouchableHighlight
+          style={{ alignSelf: "center", marginBottom: 25 }}
+          activeOpacity={1}
+          underlayColor={blue}
+          onShowUnderlay={() => setFontColor(lightBlue)}
+          onPress={() => {
+            setFontColor(lightBrown);
+            setScanned(false);
+          }}
+        >
+          <Text
+            style={{
+              textAlign: "center",
+              color: fontColor,
+              fontSize: 35,
+              fontFamily: "Alata_400Regular",
+            }}
+          >
+            Tap to Scan Again
+          </Text>
+        </TouchableHighlight>
+        // <Button
+        //   style={{ selfAlign: "center", width: "50%" }}
+        //   title={"Tap to Scan Again"}
+        //   onPress={() => setScanned(false)}
+        // />
       )}
     </View>
   );

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -13,26 +13,14 @@ import { BarCodeScanner } from "expo-barcode-scanner";
 import { blue, lightBrown, lightBlue } from "../../colours";
 import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
 
-export default function BarcodeScanner({ route, navigation }) {
+export default function BarcodeScanner({ navigation }) {
   const imageUri = useSelector(selectUrl);
-  console.log("is the url from barcode image here?", imageUri);
   const checkUrl = imageUri && imageUri.split(":");
-  console.log("what is checkUrl", checkUrl);
-
-  const back = route.params;
-  console.log("what is route.parms", route.params);
-  console.log("what is back", back);
   const dispatch = useDispatch();
   useFonts({ Alata_400Regular });
   const [hasPermission, setHasPermission] = useState(null);
   const [scanned, setScanned] = useState(false);
   const [fontColor, setFontColor] = useState(lightBrown);
-
-  useEffect(() => {
-    setScanned(false);
-  }, [back]);
-
-  console.log("what is scanned?", scanned);
 
   useEffect(() => {
     (async () => {
@@ -48,7 +36,8 @@ export default function BarcodeScanner({ route, navigation }) {
   };
 
   useEffect(() => {
-    if (checkUrl && checkUrl[0] === "https") {
+    if (scanned && checkUrl && checkUrl[0] === "https") {
+      setScanned(false);
       navigation.navigate("Preview", imageUri);
     }
   }, [imageUri]);

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -2,26 +2,18 @@ import React, { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchBarcodeLabels } from "../../store/labels/actions";
 import { selectUrl } from "../../store/labels/selectors";
-import {
-  Text,
-  View,
-  StyleSheet,
-  Button,
-  TouchableHighlight,
-} from "react-native";
+import { Text, View, StyleSheet, TouchableHighlight } from "react-native";
 import { BarCodeScanner } from "expo-barcode-scanner";
 import { blue, lightBrown, lightBlue } from "../../colours";
 import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
 
 export default function BarcodeScanner({ navigation }) {
-  const imageUri = useSelector(selectUrl);
-  console.log("is the imageUri here in barcodescanner?", imageUri);
-  const checkUrl = imageUri && imageUri.split(":");
   const dispatch = useDispatch();
   useFonts({ Alata_400Regular });
   const [hasPermission, setHasPermission] = useState(null);
   const [scanned, setScanned] = useState(false);
   const [fontColor, setFontColor] = useState(lightBrown);
+  const imageUri = useSelector(selectUrl);
 
   useEffect(() => {
     (async () => {
@@ -30,20 +22,14 @@ export default function BarcodeScanner({ navigation }) {
     })();
   }, []);
 
-  const handleBarCodeScanned = async ({ type, data }) => {
-    console.log(`type: ${type} with barcode number: ${data}`);
+  const handleBarCodeScanned = async ({ data }) => {
     setScanned(true);
     dispatch(fetchBarcodeLabels(data));
   };
 
   useEffect(() => {
-    console.log("what is checkURL??", checkUrl);
-    if (scanned && checkUrl && checkUrl[0] === "https") {
+    if (scanned && imageUri) {
       setScanned(false);
-      console.log(
-        "what do we have here before navigating to preview?",
-        imageUri
-      );
       navigation.navigate("Preview", { imageUri });
     }
   }, [imageUri]);
@@ -102,11 +88,6 @@ export default function BarcodeScanner({ navigation }) {
             Tap to Scan Again
           </Text>
         </TouchableHighlight>
-        // <Button
-        //   style={{ selfAlign: "center", width: "50%" }}
-        //   title={"Tap to Scan Again"}
-        //   onPress={() => setScanned(false)}
-        // />
       )}
     </View>
   );

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from "react";
+import { Text, View, StyleSheet, Button } from "react-native";
+import { BarCodeScanner } from "expo-barcode-scanner";
+
+export default function BarcodeScanner() {
+  const [hasPermission, setHasPermission] = useState(null);
+  const [scanned, setScanned] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === "granted");
+    })();
+  }, []);
+
+  const handleBarCodeScanned = ({ type, data }) => {
+    setScanned(true);
+    alert(`Bar code with type ${type} and data ${data} has been scanned!`);
+  };
+
+  if (hasPermission === null) {
+    return <Text>Requesting for camera permission</Text>;
+  }
+  if (hasPermission === false) {
+    return <Text>No access to camera</Text>;
+  }
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        flexDirection: "column",
+        justifyContent: "flex-end",
+      }}
+    >
+      <BarCodeScanner
+        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+        style={StyleSheet.absoluteFillObject}
+      />
+
+      {scanned && (
+        <Button title={"Tap to Scan Again"} onPress={() => setScanned(false)} />
+      )}
+    </View>
+  );
+}

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchBarcodeLabels } from "../../store/labels/actions";
 import {
   Text,
   View,
@@ -11,6 +13,7 @@ import { blue, lightBrown, lightBlue } from "../../colours";
 import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
 
 export default function BarcodeScanner() {
+  const dispatch = useDispatch();
   useFonts({ Alata_400Regular });
   const [hasPermission, setHasPermission] = useState(null);
   const [scanned, setScanned] = useState(false);
@@ -24,8 +27,9 @@ export default function BarcodeScanner() {
   }, []);
 
   const handleBarCodeScanned = ({ type, data }) => {
+    console.log(`type: ${type} with barcode number: ${data}`);
     setScanned(true);
-    alert(`Bar code with type ${type} and data ${data} has been scanned!`);
+    dispatch(fetchBarcodeLabels(data));
   };
 
   if (hasPermission === null) {
@@ -34,8 +38,6 @@ export default function BarcodeScanner() {
   if (hasPermission === false) {
     return <Text>No access to camera</Text>;
   }
-
-  console.log("fontcolor", fontColor);
 
   return (
     <View

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchBarcodeLabels } from "../../store/labels/actions";
+import { selectUrl } from "../../store/labels/selectors";
 import {
   Text,
   View,
@@ -12,12 +13,26 @@ import { BarCodeScanner } from "expo-barcode-scanner";
 import { blue, lightBrown, lightBlue } from "../../colours";
 import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
 
-export default function BarcodeScanner() {
+export default function BarcodeScanner({ route, navigation }) {
+  const imageUri = useSelector(selectUrl);
+  console.log("is the url from barcode image here?", imageUri);
+  const checkUrl = imageUri && imageUri.split(":");
+  console.log("what is checkUrl", checkUrl);
+
+  const back = route.params;
+  console.log("what is route.parms", route.params);
+  console.log("what is back", back);
   const dispatch = useDispatch();
   useFonts({ Alata_400Regular });
   const [hasPermission, setHasPermission] = useState(null);
   const [scanned, setScanned] = useState(false);
   const [fontColor, setFontColor] = useState(lightBrown);
+
+  useEffect(() => {
+    setScanned(false);
+  }, [back]);
+
+  console.log("what is scanned?", scanned);
 
   useEffect(() => {
     (async () => {
@@ -26,11 +41,17 @@ export default function BarcodeScanner() {
     })();
   }, []);
 
-  const handleBarCodeScanned = ({ type, data }) => {
+  const handleBarCodeScanned = async ({ type, data }) => {
     console.log(`type: ${type} with barcode number: ${data}`);
     setScanned(true);
     dispatch(fetchBarcodeLabels(data));
   };
+
+  useEffect(() => {
+    if (checkUrl && checkUrl[0] === "https") {
+      navigation.navigate("Preview", imageUri);
+    }
+  }, [imageUri]);
 
   if (hasPermission === null) {
     return <Text>Requesting for camera permission</Text>;

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -1,8 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchBarcodeLabels } from "../../store/labels/actions";
+import { removeLabels } from "../../store/labels/actions";
 import { selectUrl } from "../../store/labels/selectors";
-import { Text, View, StyleSheet, TouchableHighlight } from "react-native";
+import { selectMessage } from "../../store/labels/selectors";
+import {
+  Text,
+  View,
+  StyleSheet,
+  TouchableHighlight,
+  Alert,
+} from "react-native";
 import { BarCodeScanner } from "expo-barcode-scanner";
 import { blue, lightBrown, lightBlue } from "../../colours";
 import { useFonts, Alata_400Regular } from "@expo-google-fonts/alata";
@@ -15,6 +23,13 @@ export default function BarcodeScanner({ navigation }) {
   const [fontColor, setFontColor] = useState(lightBrown);
   const imageUri = useSelector(selectUrl);
 
+  const message = useSelector(selectMessage);
+
+  if (message) {
+    Alert.alert(message);
+    dispatch(removeLabels());
+  }
+
   useEffect(() => {
     (async () => {
       const { status } = await BarCodeScanner.requestPermissionsAsync();
@@ -23,8 +38,8 @@ export default function BarcodeScanner({ navigation }) {
   }, []);
 
   const handleBarCodeScanned = async ({ data }) => {
-    setScanned(true);
     dispatch(fetchBarcodeLabels(data));
+    setScanned(true);
   };
 
   useEffect(() => {

--- a/src/screens/BarcodeScanner/index.js
+++ b/src/screens/BarcodeScanner/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Text, View, StyleSheet, Button } from "react-native";
 import { BarCodeScanner } from "expo-barcode-scanner";
+import { blue, lightBrown } from "../../colours";
 
 export default function BarcodeScanner() {
   const [hasPermission, setHasPermission] = useState(null);
@@ -30,9 +31,17 @@ export default function BarcodeScanner() {
       style={{
         flex: 1,
         flexDirection: "column",
-        justifyContent: "flex-end",
+        backgroundColor: blue,
       }}
     >
+      <Text
+        style={{
+          textAlign: "center",
+          color: lightBrown,
+        }}
+      >
+        Aim at the barcode!
+      </Text>
       <BarCodeScanner
         onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
         style={StyleSheet.absoluteFillObject}

--- a/src/screens/Camera/index.js
+++ b/src/screens/Camera/index.js
@@ -51,7 +51,7 @@ export default function App({ navigation }) {
                   dispatch(fetchImageLabels(url));
                 })
                 .then(() => setLoading(false))
-                .then(() => navigation.navigate("Preview", imageUri))
+                .then(() => navigation.navigate("Preview", { imageUri }))
                 .catch((e) =>
                   console.log("getting downloadURL of image error", e.message)
                 );

--- a/src/screens/Camera/index.js
+++ b/src/screens/Camera/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Text, View, TouchableOpacity } from "react-native";
 import { Camera } from "expo-camera";
 import { useDispatch } from "react-redux";
-import { fetchLabels } from "../../store/labels/actions";
+import { fetchImageLabels } from "../../store/labels/actions";
 import * as firebase from "firebase";
 import Loading from "../../components/Loading";
 
@@ -48,7 +48,7 @@ export default function App({ navigation }) {
               imageRef
                 .getDownloadURL()
                 .then((url) => {
-                  dispatch(fetchLabels(url));
+                  dispatch(fetchImageLabels(url));
                 })
                 .then(() => setLoading(false))
                 .then(() => navigation.navigate("Preview", imageUri))

--- a/src/screens/HomeScreen/index.js
+++ b/src/screens/HomeScreen/index.js
@@ -35,7 +35,7 @@ export default function HomeScreen({ navigation }) {
         <HomeButton
           style={{ justifyContent: "top" }}
           title="Scan Barcode"
-          onPress={() => navigation.navigate("HomeScreen")}
+          onPress={() => navigation.navigate("BarcodeScanner")}
           backgroundColor="#3b7080ff"
           color="#b3d89cff"
           font="AlfaSlabOne_400Regular"

--- a/src/screens/HomeScreen/index.js
+++ b/src/screens/HomeScreen/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, View, Button } from "react-native";
+import { View } from "react-native";
 import HomeButton from "../../components/HomeButton";
 
 import { AppLoading } from "expo";

--- a/src/screens/RecipeDetails/index.js
+++ b/src/screens/RecipeDetails/index.js
@@ -5,7 +5,6 @@ import {
   Image,
   ScrollView,
   StyleSheet,
-  ActivityIndicator,
   TouchableWithoutFeedback,
   ImageBackground,
 } from "react-native";
@@ -26,14 +25,14 @@ const blue = "#3b7080ff";
 const lightBlue = "#57AFCA";
 const salmon = "#f79f79ff";
 
-export default function RecipeDetails({ route, navigation }) {
+export default function RecipeDetails({ route }) {
   const item = route.params;
   const [details, setDetails] = useState([item]);
   const [check, setCheck] = useState(false);
   const [ingredientLines, setIngredientLines] = useState({});
   const [moreInfo, setMoreInfo] = useState(false);
 
-  const [fontsLoaded] = useFonts({
+  useFonts({
     AlfaSlabOne_400Regular,
     Alata_400Regular,
   });
@@ -42,33 +41,12 @@ export default function RecipeDetails({ route, navigation }) {
     const items = item.ingredients.map((ingredient) => {
       return ingredient.text;
     });
-
-    console.log("what is items here?", items);
-
     const object = items.reduce(
       (a, key) => Object.assign(a, { [key]: false }),
       {}
     );
-
-    console.log("what is obejct", object);
-
     setIngredientLines(object);
-
-    // const what = items.map((i) => {
-    //   if(Object.prototype.hasOwnProperty.call(object, i)){
-
-    //   }
-    // });
-
-    // console.log("what is whatttttttt", what);
-
-    // for (const [key, value] of Object.entries(object)) {
-    //   setIngredientLines([...ingredientLines, { [key]: value }]);
-    //   console.log(`what is going on here! ${key}: ${value}`);
-    // }
   }, [item]);
-
-  console.log("what is ingredientlines", ingredientLines);
 
   return (
     <View style={{ flex: 1, backgroundColor: "#b3d89cff" }}>
@@ -254,16 +232,12 @@ export default function RecipeDetails({ route, navigation }) {
                       : require("../../images/placeholder.png");
                     const thisIngredientLine = ingredient.text;
 
-                    const thisthing = ingredientLines[thisIngredientLine];
-                    console.log("what is thisthing", thisthing);
-
                     return (
                       <TouchableWithoutFeedback
                         key={
                           ingredient.text + ingredient.weight + ingredient.image
                         }
                         onPress={() => {
-                          console.log("pressed");
                           setCheck(!check);
                           ingredientLines[thisIngredientLine] === false
                             ? setIngredientLines({

--- a/src/screens/Recipes/index.js
+++ b/src/screens/Recipes/index.js
@@ -5,7 +5,7 @@ import { selectRecipes } from "../../store/recipes/selectors";
 import Recipe from "../../components/Recipe";
 import Loading from "../../components/Loading";
 
-export default function Recipes({ route, navigation }) {
+export default function Recipes({ navigation }) {
   const recipes = useSelector(selectRecipes);
 
   if (!recipes) {

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -25,8 +25,6 @@ export default function index({ route, navigation }) {
     navigation.navigate("Recipes");
   }
 
-  const back = "false";
-
   return (
     <View
       style={{
@@ -91,7 +89,7 @@ export default function index({ route, navigation }) {
             title="TRY AGAIN"
             onPress={() => {
               if (nameOfProduct) {
-                navigation.navigate("BarcodeScanner", back);
+                navigation.navigate("BarcodeScanner");
               } else {
                 navigation.navigate("Camera");
               }

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Text,
   View,
@@ -9,13 +9,23 @@ import {
 } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 import { getRecipes } from "../../store/recipes/actions";
+import { removeLabels } from "../../store/labels/actions";
 import { selectLabels } from "../../store/labels/selectors";
 import { selectNameOfProduct } from "../../store/labels/selectors";
+import { selectUrl } from "../../store/labels/selectors";
 
 export default function index({ route, navigation }) {
-  const imageUri = route.params;
+  const { imageUri } = route.params || {};
+  console.log("what is route.params", route.params);
+  console.log("what is imageURI in preview???", imageUri);
   const labels = useSelector(selectLabels);
   const nameOfProduct = useSelector(selectNameOfProduct);
+  const urlll = useSelector(selectUrl);
+
+  console.log("labels", labels);
+  console.log("nameOfProduct", nameOfProduct);
+  console.log("urlll", urlll);
+
   const dispatch = useDispatch();
   const [foodLabel, setFoodLabel] = useState("");
 
@@ -36,7 +46,11 @@ export default function index({ route, navigation }) {
       ) : (
         <Image
           style={{ width: "100%", height: "50%" }}
-          source={{ uri: imageUri }}
+          source={
+            imageUri === {}
+              ? require("../../images/placeholder.png")
+              : { uri: imageUri }
+          }
         />
       )}
       <View
@@ -89,8 +103,12 @@ export default function index({ route, navigation }) {
             title="TRY AGAIN"
             onPress={() => {
               if (nameOfProduct) {
+                setFoodLabel("");
+                dispatch(removeLabels());
                 navigation.navigate("BarcodeScanner");
               } else {
+                setFoodLabel("");
+                dispatch(removeLabels());
                 navigation.navigate("Camera");
               }
             }}
@@ -99,8 +117,12 @@ export default function index({ route, navigation }) {
             title={nameOfProduct ? "Try Camera" : "Try Barcode Scanner"}
             onPress={() => {
               if (nameOfProduct) {
+                setFoodLabel("");
+                dispatch(removeLabels());
                 navigation.navigate("Camera");
               } else {
+                setFoodLabel("");
+                dispatch(removeLabels());
                 navigation.navigate("BarcodeScanner");
               }
             }}

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -10,13 +10,14 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import { getRecipes } from "../../store/recipes/actions";
 import { selectLabels } from "../../store/labels/selectors";
+import { selectNameOfProduct } from "../../store/labels/selectors";
 
 export default function index({ route, navigation }) {
   const imageUri = route.params;
   const labels = useSelector(selectLabels);
+  const nameOfProduct = useSelector(selectNameOfProduct);
   const dispatch = useDispatch();
   const [foodLabel, setFoodLabel] = useState("");
-  console.log("are the labels in preview??", labels);
 
   function fetchRecipes(event, foodLabel) {
     event.persist();
@@ -24,16 +25,22 @@ export default function index({ route, navigation }) {
     navigation.navigate("Recipes");
   }
 
+  const back = "false";
+
   return (
     <View
       style={{
         flex: 1,
       }}
     >
-      <Image
-        style={{ width: "100%", height: "50%" }}
-        source={{ uri: imageUri }}
-      />
+      {!imageUri ? (
+        <Text>This is the name of the product: {nameOfProduct}</Text>
+      ) : (
+        <Image
+          style={{ width: "100%", height: "50%" }}
+          source={{ uri: imageUri }}
+        />
+      )}
       <View
         style={{
           width: "100%",
@@ -82,7 +89,23 @@ export default function index({ route, navigation }) {
         >
           <Button
             title="TRY AGAIN"
-            onPress={() => navigation.navigate("Camera")}
+            onPress={() => {
+              if (nameOfProduct) {
+                navigation.navigate("BarcodeScanner", back);
+              } else {
+                navigation.navigate("Camera");
+              }
+            }}
+          />
+          <Button
+            title={nameOfProduct ? "Try Camera" : "Try Barcode Scanner"}
+            onPress={() => {
+              if (nameOfProduct) {
+                navigation.navigate("Camera");
+              } else {
+                navigation.navigate("BarcodeScanner");
+              }
+            }}
           />
           <Button
             title="NILES FETCH RECIPES!"

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Text,
   View,
@@ -12,19 +12,11 @@ import { getRecipes } from "../../store/recipes/actions";
 import { removeLabels } from "../../store/labels/actions";
 import { selectLabels } from "../../store/labels/selectors";
 import { selectNameOfProduct } from "../../store/labels/selectors";
-import { selectUrl } from "../../store/labels/selectors";
 
 export default function index({ route, navigation }) {
   const { imageUri } = route.params || {};
-  console.log("what is route.params", route.params);
-  console.log("what is imageURI in preview???", imageUri);
   const labels = useSelector(selectLabels);
   const nameOfProduct = useSelector(selectNameOfProduct);
-  const urlll = useSelector(selectUrl);
-
-  console.log("labels", labels);
-  console.log("nameOfProduct", nameOfProduct);
-  console.log("urlll", urlll);
 
   const dispatch = useDispatch();
   const [foodLabel, setFoodLabel] = useState("");

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Text,
   View,
@@ -6,12 +6,16 @@ import {
   Image,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 import { getRecipes } from "../../store/recipes/actions";
 import { removeLabels } from "../../store/labels/actions";
+import { removeRecipes } from "../../store/recipes/actions";
 import { selectLabels } from "../../store/labels/selectors";
 import { selectNameOfProduct } from "../../store/labels/selectors";
+import { selectRecipes } from "../../store/recipes/selectors";
+import Loading from "../../components/Loading";
 
 export default function index({ route, navigation }) {
   const { imageUri } = route.params || {};
@@ -20,11 +24,29 @@ export default function index({ route, navigation }) {
 
   const dispatch = useDispatch();
   const [foodLabel, setFoodLabel] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const recipes = useSelector(selectRecipes);
 
   function fetchRecipes(event, foodLabel) {
     event.persist();
+    setLoading(true);
     dispatch(getRecipes(foodLabel));
-    navigation.navigate("Recipes");
+  }
+
+  useEffect(() => {
+    if (recipes && recipes.message) {
+      setLoading(false);
+      Alert.alert(recipes.message);
+      dispatch(removeRecipes());
+    } else if (recipes) {
+      setLoading(false);
+      navigation.navigate("Recipes");
+    }
+  }, [recipes]);
+
+  if (loading) {
+    return <Loading />;
   }
 
   return (

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -13,6 +13,7 @@ import { getRecipes } from "../../store/recipes/actions";
 import { removeLabels } from "../../store/labels/actions";
 import { removeRecipes } from "../../store/recipes/actions";
 import { selectLabels } from "../../store/labels/selectors";
+import { selectMessage } from "../../store/labels/selectors";
 import { selectNameOfProduct } from "../../store/labels/selectors";
 import { selectRecipes } from "../../store/recipes/selectors";
 import Loading from "../../components/Loading";
@@ -20,8 +21,8 @@ import Loading from "../../components/Loading";
 export default function index({ route, navigation }) {
   const { imageUri } = route.params || {};
   const labels = useSelector(selectLabels);
+  const message = useSelector(selectMessage);
   const nameOfProduct = useSelector(selectNameOfProduct);
-
   const dispatch = useDispatch();
   const [foodLabel, setFoodLabel] = useState("");
   const [loading, setLoading] = useState(false);
@@ -39,7 +40,7 @@ export default function index({ route, navigation }) {
       setLoading(false);
       Alert.alert(recipes.message);
       dispatch(removeRecipes());
-    } else if (recipes) {
+    } else if (recipes && loading) {
       setLoading(false);
       navigation.navigate("Recipes");
     }
@@ -47,6 +48,10 @@ export default function index({ route, navigation }) {
 
   if (loading) {
     return <Loading />;
+  }
+
+  if (message) {
+    Alert.alert(message);
   }
 
   return (

--- a/src/screens/preview/index.js
+++ b/src/screens/preview/index.js
@@ -16,6 +16,7 @@ export default function index({ route, navigation }) {
   const labels = useSelector(selectLabels);
   const dispatch = useDispatch();
   const [foodLabel, setFoodLabel] = useState("");
+  console.log("are the labels in preview??", labels);
 
   function fetchRecipes(event, foodLabel) {
     event.persist();

--- a/src/store/labels/actions.js
+++ b/src/store/labels/actions.js
@@ -9,11 +9,21 @@ export const setLabels = (labels) => ({
   payload: labels,
 });
 
-export const fetchLabels = (imageUrl) => {
+export const fetchImageLabels = (imageUrl) => {
   return async (dispatch, getState) => {
     const response = await axios.post(`${server}/analyse/image`, {
       imageUrl,
     });
+    console.log("what is in the response?", response.data);
     dispatch(setLabels(response.data));
+  };
+};
+
+export const fetchBarcodeLabels = (barcode) => {
+  console.log("what is barcode in action?", barcode);
+  return async (dispatch, getState) => {
+    const response = await axios.get(`${server}/analyse/barcode/${barcode}`);
+    dispatch(setLabels(response.data));
+    console.log("what is in the response?", response.data);
   };
 };

--- a/src/store/labels/actions.js
+++ b/src/store/labels/actions.js
@@ -14,16 +14,18 @@ export const fetchImageLabels = (imageUrl) => {
     const response = await axios.post(`${server}/analyse/image`, {
       imageUrl,
     });
-    console.log("what is in the response?", response.data);
+    console.log("what is responds.data for imagelabels", response.data);
+
     dispatch(setLabels(response.data));
   };
 };
 
 export const fetchBarcodeLabels = (barcode) => {
-  console.log("what is barcode in action?", barcode);
+  console.log("what is the barcode in action", barcode);
   return async (dispatch, getState) => {
     const response = await axios.get(`${server}/analyse/barcode/${barcode}`);
+    console.log("what is response", response);
+
     dispatch(setLabels(response.data));
-    console.log("what is in the response?", response.data);
   };
 };

--- a/src/store/labels/actions.js
+++ b/src/store/labels/actions.js
@@ -19,7 +19,6 @@ export const fetchImageLabels = (imageUrl) => {
     const response = await axios.post(`${server}/analyse/image`, {
       imageUrl,
     });
-
     dispatch(setLabels(response.data));
   };
 };

--- a/src/store/labels/actions.js
+++ b/src/store/labels/actions.js
@@ -27,7 +27,6 @@ export const fetchImageLabels = (imageUrl) => {
 export const fetchBarcodeLabels = (barcode) => {
   return async (dispatch, getState) => {
     const response = await axios.get(`${server}/analyse/barcode/${barcode}`);
-
     dispatch(setLabels(response.data));
   };
 };

--- a/src/store/labels/actions.js
+++ b/src/store/labels/actions.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 export const FETCH_LABELS_SUCCESS = "FETCH_LABELS_SUCCESS";
+export const REMOVE_LABELS_SUCCESS = "REMOVE_LABELS_SUCCESS";
 
 const server = "http://192.168.178.87:4000";
 
@@ -9,22 +10,23 @@ export const setLabels = (labels) => ({
   payload: labels,
 });
 
+export const removeLabels = () => ({
+  type: REMOVE_LABELS_SUCCESS,
+});
+
 export const fetchImageLabels = (imageUrl) => {
   return async (dispatch, getState) => {
     const response = await axios.post(`${server}/analyse/image`, {
       imageUrl,
     });
-    console.log("what is responds.data for imagelabels", response.data);
 
     dispatch(setLabels(response.data));
   };
 };
 
 export const fetchBarcodeLabels = (barcode) => {
-  console.log("what is the barcode in action", barcode);
   return async (dispatch, getState) => {
     const response = await axios.get(`${server}/analyse/barcode/${barcode}`);
-    console.log("what is response", response);
 
     dispatch(setLabels(response.data));
   };

--- a/src/store/labels/actions.js
+++ b/src/store/labels/actions.js
@@ -11,7 +11,7 @@ export const setLabels = (labels) => ({
 
 export const fetchLabels = (imageUrl) => {
   return async (dispatch, getState) => {
-    const response = await axios.post(`${server}/analyse`, {
+    const response = await axios.post(`${server}/analyse/image`, {
       imageUrl,
     });
     dispatch(setLabels(response.data));

--- a/src/store/labels/reducer.js
+++ b/src/store/labels/reducer.js
@@ -1,9 +1,12 @@
 import { FETCH_LABELS_SUCCESS } from "./actions";
+import { REMOVE_LABELS_SUCCESS } from "./actions";
 
 const initialState = {};
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case REMOVE_LABELS_SUCCESS:
+      return initialState;
     case FETCH_LABELS_SUCCESS:
       return { ...state, ...action.payload };
 

--- a/src/store/labels/selectors.js
+++ b/src/store/labels/selectors.js
@@ -1,1 +1,3 @@
 export const selectLabels = (state) => state.labels.labels;
+export const selectNameOfProduct = (state) => state.labels.name;
+export const selectUrl = (state) => state.labels.url;

--- a/src/store/labels/selectors.js
+++ b/src/store/labels/selectors.js
@@ -1,3 +1,4 @@
 export const selectLabels = (state) => state.labels.labels;
 export const selectNameOfProduct = (state) => state.labels.name;
 export const selectUrl = (state) => state.labels.url;
+export const selectMessage = (state) => state.labels.message;

--- a/src/store/labels/selectors.js
+++ b/src/store/labels/selectors.js
@@ -1,1 +1,1 @@
-export const selectLabels = (state) => state.labels.imageLabel;
+export const selectLabels = (state) => state.labels.labels;

--- a/src/store/recipes/actions.js
+++ b/src/store/recipes/actions.js
@@ -1,12 +1,17 @@
 import axios from "axios";
 
 export const FETCH_RECIPES_SUCCESS = "FETCH_RECIPES_SUCCESS";
+export const REMOVE_RECIPES_SUCCESS = "REMOVE_RECIPES_SUCCESS";
 
 const server = "http://192.168.178.87:4000";
 
 export const fetchRecipes = (recipes) => ({
   type: FETCH_RECIPES_SUCCESS,
   payload: recipes,
+});
+
+export const removeRecipes = () => ({
+  type: REMOVE_RECIPES_SUCCESS,
 });
 
 export const getRecipes = (foodLabel) => {

--- a/src/store/recipes/reducer.js
+++ b/src/store/recipes/reducer.js
@@ -1,9 +1,12 @@
 import { FETCH_RECIPES_SUCCESS } from "./actions";
+import { REMOVE_RECIPES_SUCCESS } from "./actions";
 
-const initialState = { imageUrl: null, recipes: [] };
+const initialState = { imageUrl: null, recipes: null };
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case REMOVE_RECIPES_SUCCESS:
+      return initialState;
     case FETCH_RECIPES_SUCCESS:
       const { imageUrl, recipes } = action.payload;
       return { imageUrl: imageUrl, recipes: recipes };


### PR DESCRIPTION
As a user I want to be able to scan a barcode of a product and get recipes containing this product.

I implemented expo's BarCodeScanner which gives you the type and data. Data contains the actual barcode number, which I needed to send to the backend, in order to search Open Food Facts API for the correct item. Then in the response we get the item's name and labels. 

Those labels I then set to the labels you can choose from on the preview screen (this label will be searched with for recipes). Except not every product has labels, in those cases you can search for recipes with the item's name. If there are no labels and no name, a message will be send. And for now, that message will pop up as an alert.

I added another button on the preview screen so that you are now able to go back to either camera or barcode scanner (instead of having to go back to the homepage, to be able to select the other one.)

To make everything work fine with each other, going back and forth I had to add several validations on the camera, preview and barcodeScanner screens.

And I also added colours in a separate folder so I can use them globally now.